### PR TITLE
Release/0.14.1 (#118)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -78,3 +78,13 @@ jobs:
           tag_name: '${{ steps.get_version.outputs.version }}'
           draft: true
           generate_release_notes: false
+
+      # Merge main into develop
+      - name: Merge main into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin develop
+          git checkout develop
+          git merge origin/main --no-edit
+          git push origin develop

--- a/README.md
+++ b/README.md
@@ -188,14 +188,18 @@ For each route, a popup menu can be configured, to display a popup when clicked.
 
 <img width="431" height="218" alt="navbar-card_popup" src="https://github.com/user-attachments/assets/520d85c7-9d73-4e73-b3c3-a4a6b2635dcb" />
 
-| Name          | Type                                | Default     | Description                                                                       |
-| ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
-| `url`         | string                              | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                  |
-| `icon`        | string \| [JSTemplate](#jstemplate) | `Required`  | Material icon to display as this entry icon                                       |
-| `badge`       | [Badge](#badge)                     | -           | Badge configuration                                                               |
-| `label`       | string \| [JSTemplate](#jstemplate) | -           | Label to be displayed under the given route if `show_labels` is true              |
-| `tap_action`  | [tap_action](#actions)              | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.  |
-| `hold_action` | [hold_action](#actions)             | -           | Custom hold action configuration, including 'open-popup' to display a popup menu. |
+| Name             | Type                                 | Default     | Description                                                                                                                                              |
+| ---------------- | ------------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`            | string                               | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                                                                         |
+| `icon`           | string \| [JSTemplate](#jstemplate)  | -           | Material icon to display as this entry icon.                                                                                                             |
+| `icon_selected`  | string \| [JSTemplate](#jstemplate)  | -           | Icon to be displayed when `url` matches the current browser URL                                                                                          |
+| `image`          | string \| [JSTemplate](#jstemplate)  | -           | URL of an image to display as this entry icon.                                                                                                           |
+| `image_selected` | string \| [JSTemplate](#jstemplate)  | -           | Image to be displayed when `url` matches the current browser URL                                                                                         |
+| `badge`          | [Badge](#badge)                      | -           | Badge configuration                                                                                                                                      |
+| `label`          | string \| [JSTemplate](#jstemplate)  | -           | Label to be displayed under the given route if `show_labels` is true                                                                                     |
+| `tap_action`     | [tap_action](#actions)               | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.                                                                         |
+| `hold_action`    | [hold_action](#actions)              | -           | Custom hold action configuration, including 'open-popup' to display a popup menu.                                                                        |
+| `selected`       | boolean \| [JSTemplate](#jstemplate) | -           | Controls whether to display this item as selected or not. If not defined, the selected status will be computed as `item.url == window.location.pathname` |
 
 > **Note**: `url` is required unless `tap_action` is present. If `tap_action` is defined, `url` is ignored.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -121,14 +121,6 @@ export class NavbarCard extends LitElement {
   }
 
   setConfig(config) {
-    forceDashboardPadding({
-      desktop: config.desktop ?? DEFAULT_NAVBAR_CONFIG.desktop,
-      mobile: config.mobile ?? DEFAULT_NAVBAR_CONFIG.mobile,
-      auto_padding:
-        config.layout?.auto_padding ??
-        DEFAULT_NAVBAR_CONFIG.layout?.auto_padding,
-    });
-
     // Check for template configuration
     if (config?.template) {
       // Get templates from the DOM
@@ -185,6 +177,15 @@ export class NavbarCard extends LitElement {
       if (route.double_tap_action && route.double_tap_action.action == null) {
         throw new Error('"double_tap_action" must have an "action" property');
       }
+    });
+
+    // Force dashboard padding
+    forceDashboardPadding({
+      desktop: config.desktop ?? DEFAULT_NAVBAR_CONFIG.desktop,
+      mobile: config.mobile ?? DEFAULT_NAVBAR_CONFIG.mobile,
+      auto_padding:
+        config.layout?.auto_padding ??
+        DEFAULT_NAVBAR_CONFIG.layout?.auto_padding,
     });
 
     // Store configuration
@@ -564,7 +565,10 @@ export class NavbarCard extends LitElement {
         style="${style}">
         ${popupItems
           .map((popupItem, index) => {
-            // Cache template evaluations
+            const isActive =
+              popupItem.selected != null
+                ? processTemplate<boolean>(this.hass, this, popupItem.selected)
+                : window.location.pathname == popupItem.url;
             const isHidden = processTemplate<boolean>(
               this.hass,
               this,
@@ -584,12 +588,13 @@ export class NavbarCard extends LitElement {
               popup-item 
               ${popupDirectionClassName}
               ${labelPositionClassName}
+              ${isActive ? 'active' : ''}
             "
               style="--index: ${index}"
               @click=${(e: MouseEvent) =>
                 this._handlePointerUp(e as PointerEvent, popupItem, true)}>
               <div class="button">
-                ${this._getRouteIcon(popupItem, false)}
+                ${this._getRouteIcon(popupItem, isActive)}
                 <md-ripple></md-ripple>
               </div>
               ${label ? html`<div class="label">${label}</div>` : html``}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -316,6 +316,15 @@ const POPUP_STYLES = css`
     background: var(--navbar-background-color);
     box-shadow: var(--navbar-box-shadow-desktop);
   }
+
+  .popup-item.active {
+    --icon-primary-color: var(--navbar-primary-color);
+  }
+
+  .popup-item.active .button {
+    color: var(--navbar-primary-color);
+    background: color-mix(in srgb, var(--navbar-primary-color) 30%, white);
+  }
 `;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export const DEFAULT_NAVBAR_CONFIG: NavbarCardConfig = {
   desktop: {
     show_labels: false,
     min_width: 768,
-    position: DesktopPosition.left,
+    position: DesktopPosition.bottom,
   },
   mobile: {
     show_labels: false,


### PR DESCRIPTION
* fix: auto-padding functionality not reading navbar template configuration

* fix: selected prop not working on popup items

* fix: allow users to configure _selected variant for both image and icon in popup items

* fix: DEFAULT_NAVBAR_CONFIG desktop position set to "left" instead of "bottom"

* chore: merge main into develop after release